### PR TITLE
fix around tar gz compression to make file headers consistent

### DIFF
--- a/pkg/k8smanifest/sign.go
+++ b/pkg/k8smanifest/sign.go
@@ -81,7 +81,11 @@ type ImageSigner struct {
 
 func (s *ImageSigner) Sign(inputDir, output string, imageAnnotations map[string]interface{}) ([]byte, error) {
 	var inputDataBuffer bytes.Buffer
-	err := k8ssigutil.TarGzCompress(inputDir, &inputDataBuffer, k8ssigutil.MutateOptions{AW: embedAnnotation, Annotations: imageAnnotations})
+	var mo *k8ssigutil.MutateOptions
+	if len(imageAnnotations) > 0 {
+		mo = &k8ssigutil.MutateOptions{AW: embedAnnotation, Annotations: imageAnnotations}
+	}
+	err := k8ssigutil.TarGzCompress(inputDir, &inputDataBuffer, mo)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to compress an input file/dir")
 	}

--- a/pkg/k8smanifest/verify.go
+++ b/pkg/k8smanifest/verify.go
@@ -55,10 +55,10 @@ func NewSignatureVerifier(objYAMLBytes []byte, imageRef string, pubkeyPath *stri
 			imageRef = annoImageRef
 		}
 	}
-	
+
 	i.imageRef = imageRef
 
-	if *pubkeyPath != "" {
+	if pubkeyPath != nil && *pubkeyPath != "" {
 		i.pubkeyPath = pubkeyPath
 	}
 

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -22,9 +22,13 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // AnnotationWriter represents the embedAnnotation function
@@ -35,14 +39,67 @@ type MutateOptions struct {
 	Annotations map[string]interface{}
 }
 
-func TarGzCompress(src string, buf io.Writer, mo MutateOptions) error {
+func TarGzCompress(src string, buf io.Writer, mo *MutateOptions) error {
+
 	// tar > gzip > buf
 	zr := gzip.NewWriter(buf)
 	tw := tar.NewWriter(zr)
 
 	var errV error
+
+	tarGzSrc := src
+
+	// if mutation option is specified, should mutate files before tar gz compression
+	// in order to avoid file header inconsistency
+	if mo != nil {
+		dir, err := ioutil.TempDir("", "compressing-tar-gz")
+		if err != nil {
+			return errors.Wrap(err, "error occurred during creating temp dir for tar gz compression")
+		}
+
+		basename := filepath.Base(src)
+		defer os.RemoveAll(dir)
+
+		tmpSrc := filepath.Join(dir, basename)
+		err = copyDir(src, tmpSrc)
+		if err != nil {
+			return errors.Wrap(err, "error occurred during copying src dir for tar gz compression")
+		}
+
+		errV = filepath.Walk(tmpSrc, func(file string, fi os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			// if not a dir, write file content
+			if !fi.IsDir() {
+				f, err := os.ReadFile(file)
+				if err != nil {
+					return err
+				}
+
+				data, err := mo.AW(f, mo.Annotations)
+				if err != nil {
+					return err
+				}
+
+				err = os.WriteFile(file, data, fi.Mode())
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+
+		if errV != nil {
+			return errV
+		}
+		tarGzSrc = tmpSrc
+	}
+
+	// tar gz compression
 	// walk through every file in the folder
-	errV = filepath.Walk(src, func(file string, fi os.FileInfo, err error) error {
+	errV = filepath.Walk(tarGzSrc, func(file string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -62,12 +119,7 @@ func TarGzCompress(src string, buf io.Writer, mo MutateOptions) error {
 		}
 		// if not a dir, write file content
 		if !fi.IsDir() {
-			f, err := os.ReadFile(file)
-			if err != nil {
-				return err
-			}
-
-			data, err := mo.AW(f, mo.Annotations)
+			data, err := os.ReadFile(file)
 			if err != nil {
 				return err
 			}
@@ -156,6 +208,66 @@ func TarGzDecompress(src io.Reader, dst string) error {
 			// to wait until all operations have completed.
 			fileToWrite.Close()
 		}
+	}
+	return nil
+}
+
+// copy an entire directory recursively
+func copyDir(src string, dst string) error {
+	var err error
+	var fds []os.FileInfo
+	var srcinfo os.FileInfo
+
+	if srcinfo, err = os.Stat(src); err != nil {
+		return err
+	}
+
+	if srcinfo.IsDir() {
+		if err = os.MkdirAll(dst, srcinfo.Mode()); err != nil {
+			return err
+		}
+
+		if fds, err = ioutil.ReadDir(src); err != nil {
+			return err
+		}
+		for _, fd := range fds {
+			srcfp := path.Join(src, fd.Name())
+			dstfp := path.Join(dst, fd.Name())
+
+			if fd.IsDir() {
+				if err = copyDir(srcfp, dstfp); err != nil {
+					return err
+				}
+			} else {
+				if err = copyFile(srcfp, dstfp); err != nil {
+					return err
+				}
+			}
+		}
+	} else {
+		if err = copyFile(src, dst); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// copy a single file
+func copyFile(src string, dst string) error {
+	fi, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	input, err := ioutil.ReadFile(src)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(dst, input, fi.Mode())
+	if err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- small fix for file header inconsistency error of tar gz compression
    - copy input files and mutate copied ones in order to avoid `write too long` error (= file header inconsistency) from tar compression
    - mutate files only when mutateOption is specified
- add nil check for pubkey in verify command